### PR TITLE
fix: options formatter for manpages

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -327,7 +327,7 @@ class ArgParseDirective(Directive):
             options_section += nodes.subtitle(text='Positional arguments:')
             options_section += self._format_positional_arguments(parser_info)
         for action_group in parser_info['action_groups']:
-            if 'options' in parser_info:
+            if 'options' in action_group:
                 options_section += nodes.paragraph()
                 options_section += nodes.subtitle(text=action_group['title'])
                 options_section += self._format_optional_arguments(action_group)


### PR DESCRIPTION
The "options" formatter for the manpage generation did not output any option, as the loop used a wrong key in the parser_info dictionary (likely a typo).

This patch fixes this, which results in correctly printed parser options in manpage mode.