### PR TITLE
Fixed pytest parameterization that wasn't actually parameterized

### DIFF
--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -2,14 +2,15 @@
 
 import pytest
 
-from .conftest import check_xpath, flat_dict
+from .conftest import check_xpath
 
 
 @pytest.mark.parametrize(
-    "fname,expect",
-    flat_dict(
-        {
-            'index.html': [
+    "fname,expect_list",
+    [
+        (
+            'index.html',
+            [
                 (".//h1", 'Sample'),
                 (".//h1", 'blah-blah', False),
                 (".//div[@class='highlight']//span", 'usage'),
@@ -21,7 +22,10 @@ from .conftest import check_xpath, flat_dict
                 (".//section[@id='bar-options']", ''),
                 (".//section[@id='bar-options']/dl/dt[1]/kbd", '--bar'),
             ],
-            'subcommand-a.html': [
+        ),
+        (
+            'subcommand-a.html',
+            [
                 (".//h1", 'Sample', False),
                 (".//h1", 'Command A'),
                 (".//div[@class='highlight']//span", 'usage'),
@@ -29,7 +33,10 @@ from .conftest import check_xpath, flat_dict
                 (".//section[@id='positional-arguments']", ''),
                 (".//section[@id='positional-arguments']/dl/dt[1]/kbd", 'baz'),
             ],
-            'special-characters.html': [
+        ),
+        (
+            'special-characters.html',
+            [
                 (".//h1", 'Sample', False),
                 (".//h1", 'Special Characters'),
                 (".//section/dl/dd/p", 'Default:'),
@@ -37,11 +44,12 @@ from .conftest import check_xpath, flat_dict
                 (".//section/dl/dd/p/code/span", "'*.rst"),
                 (".//section/dl/dd/p/code/span", r"\['\*.rst',"),
             ],
-        }
-    ),
+        ),
+    ],
 )
 @pytest.mark.sphinx('html', testroot='default-html')
-def test_default_html(app, cached_etree_parse, fname, expect):
+def test_default_html(app, cached_etree_parse, fname, expect_list):
     app.build()
     print(app.outdir / fname)
-    check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)
+    for expect in expect_list:
+        check_xpath(cached_etree_parse(app.outdir / fname), fname, *expect)


### PR DESCRIPTION
Very minor but it bothered me: the second list of parameters isn't actually a parameter, they don't have an effect on the results. They're simply different assertions and I don't think there's any reason to put them in separate tests.