### PR TITLE
Fixes Issue #45

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -445,7 +445,7 @@ class ArgParseDirective(Directive):
         # try open with shutil which
         try:
             return open(shutil.which(self.options['filename']))
-        except OSError:
+        except (OSError, TypeError):
             pass
         # raise exception
         raise FileNotFoundError(self.options['filename'])


### PR DESCRIPTION
Code is not equipped to handle scenario when ```shutil.which``` return ```None```. Adding ```TypeError``` in Exception to handle such scenario.