### PR TITLE
Fix suppressed default visible

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -30,6 +30,9 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
+"test/sample-default-supressed.py" = [
+    "N999",  # invalid module name
+]
 "test/sample-directive-opts.py" = [
     "N999",  # invalid module name
 ]

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -86,7 +86,7 @@ def render_list(l, markdown_help, settings=None):
         return all_children
 
 
-def is_suppressed(item):
+def _is_suppressed(item):
     """Return whether item should not be printed."""
     if item is None:
         return True
@@ -159,7 +159,7 @@ def print_action_groups(
                     )
                 if 'help' in entry:
                     arg.append(entry['help'])
-                if not is_suppressed(entry['default']):
+                if not _is_suppressed(entry['default']):
                     # Put the default value in a literal block,
                     # but escape backticks already in the string
                     default_str = str(entry['default']).replace('`', r'\`')
@@ -419,7 +419,7 @@ class ArgParseDirective(Directive):
             opt_items = []
             for name in opt['name']:
                 option_declaration = [nodes.option_string(text=name)]
-                if not is_suppressed(opt['default']):
+                if not _is_suppressed(opt['default']):
                     option_declaration += nodes.option_argument(
                         '', text='=' + str(opt['default'])
                     )

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -86,6 +86,14 @@ def render_list(l, markdown_help, settings=None):
         return all_children
 
 
+def is_suppressed(item):
+    """Return whether item should not be printed."""
+    if item is None:
+        return True
+    item = str(item).replace('"', '').replace("'", '')
+    return item == '==SUPPRESS=='
+
+
 def print_action_groups(
     data,
     nested_content,
@@ -151,10 +159,7 @@ def print_action_groups(
                     )
                 if 'help' in entry:
                     arg.append(entry['help'])
-                if entry['default'] is not None and entry['default'] not in [
-                    '"==SUPPRESS=="',
-                    '==SUPPRESS==',
-                ]:
+                if not is_suppressed(entry['default']):
                     # Put the default value in a literal block,
                     # but escape backticks already in the string
                     default_str = str(entry['default']).replace('`', r'\`')
@@ -414,10 +419,7 @@ class ArgParseDirective(Directive):
             opt_items = []
             for name in opt['name']:
                 option_declaration = [nodes.option_string(text=name)]
-                if opt['default'] is not None and opt['default'] not in [
-                    '"==SUPPRESS=="',
-                    '==SUPPRESS==',
-                ]:
+                if not is_suppressed(opt['default']):
                     option_declaration += nodes.option_argument(
                         '', text='=' + str(opt['default'])
                     )

--- a/test/roots/test-default-html/default-suppressed.rst
+++ b/test/roots/test-default-html/default-suppressed.rst
@@ -1,0 +1,7 @@
+Default suppressed
+==================
+
+.. argparse::
+   :filename: test/sample-default-supressed.py
+   :prog: sample-default-suppressed
+   :func: get_parser

--- a/test/sample-default-supressed.py
+++ b/test/sample-default-supressed.py
@@ -1,0 +1,7 @@
+from argparse import ArgumentParser
+
+
+def get_parser():
+    parser = ArgumentParser(prog='sample-default-suppressed', description='Test suppression of version default')
+    parser.add_argument('--version', help='print version number', action='version', version='1.2.3')
+    return parser

--- a/test/sample-default-supressed.py
+++ b/test/sample-default-supressed.py
@@ -2,6 +2,10 @@ from argparse import ArgumentParser
 
 
 def get_parser():
-    parser = ArgumentParser(prog='sample-default-suppressed', description='Test suppression of version default')
-    parser.add_argument('--version', help='print version number', action='version', version='1.2.3')
+    parser = ArgumentParser(
+        prog='sample-default-suppressed', description='Test suppression of version default'
+    )
+    parser.add_argument(
+        '--version', help='print version number', action='version', version='1.2.3'
+    )
     return parser

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -31,13 +31,17 @@ def check_xpath(etree, fname, path, check, be_found=True):
         if be_found:
             if any(rex.search(get_text(node)) for node in nodes):
                 return
-            msg = (f'{check!r} not found in any node matching path {path} in {fname}: '
-                   f'{[node.text for node in nodes]!r}')
+            msg = (
+                f'{check!r} not found in any node matching path {path} in {fname}: '
+                f'{[node.text for node in nodes]!r}'
+            )
         else:
             if all(not rex.search(get_text(node)) for node in nodes):
                 return
-            msg = (f'Found {check!r} in a node matching path {path} in {fname}: '
-                   f'{[node.text for node in nodes]!r}')
+            msg = (
+                f'Found {check!r} in a node matching path {path} in {fname}: '
+                f'{[node.text for node in nodes]!r}'
+            )
 
         raise AssertionError(msg)
 
@@ -85,10 +89,10 @@ def check_xpath(etree, fname, path, check, be_found=True):
         (
             'default-suppressed.html',
             [
-                (".//h1", 'Sample', False),
-                (".//h1", 'Default suppressed'),
-                (".//h2", 'Named Arguments'),
-                (".//section/dl/dd/p", 'Default', False),
+                ('.//h1', 'Sample', False),
+                ('.//h1', 'Default suppressed'),
+                ('.//h2', 'Named Arguments'),
+                ('.//section/dl/dd/p', 'Default', False),
             ],
         ),
     ],

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -82,6 +82,15 @@ def check_xpath(etree, fname, path, check, be_found=True):
                 ('.//section/dl/dd/p/code/span', r"\['\*.rst',"),
             ],
         ),
+        (
+            'default-suppressed.html',
+            [
+                (".//h1", 'Sample', False),
+                (".//h1", 'Default suppressed'),
+                (".//h2", 'Named Arguments'),
+                (".//section/dl/dd/p", 'Default', False),
+            ],
+        ),
     ],
 )
 @pytest.mark.sphinx('html', testroot='default-html')

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -31,14 +31,14 @@ def check_xpath(etree, fname, path, check, be_found=True):
         if be_found:
             if any(rex.search(get_text(node)) for node in nodes):
                 return
+            msg = (f'{check!r} not found in any node matching path {path} in {fname}: '
+                   f'{[node.text for node in nodes]!r}')
         else:
             if all(not rex.search(get_text(node)) for node in nodes):
                 return
+            msg = (f'Found {check!r} in a node matching path {path} in {fname}: '
+                   f'{[node.text for node in nodes]!r}')
 
-        msg = (
-            f'{check!r} not found in any node matching path {path} in {fname}: '
-            f'{[node.text for node in nodes]!r}'
-        )
         raise AssertionError(msg)
 
 


### PR DESCRIPTION
For some parser arguments (e.g., `action='version'`), the `"==SUPPRESSED=="` default would be unexpectedly shown.

Added also regression test.