### PR TITLE
support reading Argparse instances inside classes

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -471,14 +471,18 @@ class ArgParseDirective(Directive):
 
         # Skip this if we're dealing with a local file, since it obviously can't be imported
         if 'filename' not in self.options:
+            _elements = attr_name.split('.')
             try:
-                mod = __import__(module_name, globals(), locals(), [attr_name])
+                mod = __import__(module_name, globals(), locals(), [_elements[0]])
             except ImportError:
-                raise self.error(f'Failed to import "{attr_name}" from "{module_name}".\n{sys.exc_info()[1]}')
-
-            if not hasattr(mod, attr_name):
-                raise self.error(('Module "%s" has no attribute "%s"\nIncorrect argparse :module: or :func: values?') % (module_name, attr_name))
-            func = getattr(mod, attr_name)
+                raise self.error(f'Failed to import "{_elements[0]}" from "{module_name}".\n{sys.exc_info()[1]}')
+            obj = mod
+            for i in _elements:
+                if not hasattr(obj, i):
+                    raise self.error(f'"{obj}" has no attribute "{i}"\n'
+                                      'Incorrect argparse :module: or :func: values?')
+                obj = getattr(obj, i)
+            func = obj
 
         if isinstance(func, ArgumentParser):
             parser = func


### PR DESCRIPTION
So far, shphinxarg only has support for reading/importing Argparse instances from global variables/attributes within a module.  However, there are use cases where Argparse is used inside classes of a module, not as a global variable.  This is particularly the case for uses of 'argparse' in the context of CLI / REPL style user interfaces, such as for example those built using the 'cmd2' module.

This change introduces the ability to specify a path in ':func:' using the '.'-notation (e.g. 'PysimApp.bulk_script_parser').

Initial patch by: Harald Welte <laforge@osmocom.org>
Co-authored by: Vadim Yanitskiy <fixeria@osmocom.org>

This is a follow-up to https://github.com/sphinx-doc/sphinx-argparse/pull/36#event-13507765902