### PR TITLE
Ensure that the tittle id is unique on the with different subcommand

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -113,6 +113,8 @@ def print_action_groups(
             # Every action group is composed of a section, holding
             # a title, the description, and the option group (members)
             title_as_id = action_group['title'].replace(' ', '-').lower()
+            if data['name']:
+                title_as_id = f'{data["name"]}-{title_as_id}'
             if id_prefix:
                 title_as_id = f'{id_prefix}-{title_as_id}'
             section = nodes.section(ids=[title_as_id])

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -74,8 +74,8 @@ def check_xpath(etree, fname, path, check, be_found=True):
                 ('.//h1', 'Command A'),
                 (".//div[@class='highlight']//span", 'usage'),
                 ('.//h2', 'Positional Arguments'),
-                (".//section[@id='get_parser-positional-arguments']", ''),
-                (".//section[@id='get_parser-positional-arguments']/dl/dt[1]/kbd", 'baz'),
+                (".//section[@id='get_parser-A-positional-arguments']", ''),
+                (".//section[@id='get_parser-A-positional-arguments']/dl/dt[1]/kbd", 'baz'),
             ],
         ),
         (


### PR DESCRIPTION
# Motivation

I found the URL hash property of the rendered action group tittle could be repeat conflict in one page. The following is a pseudo example to reproduce:

```markdown
# xxx-cli
Some introduction of `xxx-cli` here...

## xxx-cli subcommand1
Some introduction of `xxx-cli subcommand1` here...
:::{eval-rst}
.. argparse::
   :module: xxx.cli
   :func: get_parser
   :prog: xxx-cli
   :path: subcommand1
:::

## xxx-cli subcommand2
Some introduction of `xxx-cli subcommand2` here...
:::{eval-rst}
.. argparse::
   :module: xxx.cli
   :func: get_parser
   :prog: xxx-cli
   :path: subcommand2
:::
```

# Modification
- `sphinxarg/ext.py`
  - Add the `data['name']` to the `title_as_id`.
- `test/test_default_html.py`
  - Update the unit test of subcommand.