### PR TITLE
Special formatting of ranges as choices instead of listing entries

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -87,6 +87,12 @@ def render_list(l, markdown_help, settings=None):
         return all_children
 
 
+def format_choices(choices):
+    if isinstance(choices, range) and choices.step == 1:
+        return f'Value range: {choices.start} to {choices.stop}\n'
+    return f'Possible choices: {", ".join(str(c) for c in choices)}\n'
+
+
 def _is_suppressed(item: str | None) -> bool:
     """Return whether item should not be printed."""
     if item is None:
@@ -157,9 +163,7 @@ def print_action_groups(
                 # Build the help text
                 arg = []
                 if 'choices' in entry:
-                    arg.append(
-                        f"Possible choices: {', '.join(str(c) for c in entry['choices'])}\n"
-                    )
+                    arg.append(format_choices(entry['choices']))
                 if 'help' in entry:
                     arg.append(entry['help'])
                 if not _is_suppressed(entry['default']):
@@ -400,9 +404,7 @@ class ArgParseDirective(SphinxDirective):
             elif 'choices' not in arg:
                 arg_items.append(nodes.paragraph(text='Undocumented'))
             if 'choices' in arg:
-                arg_items.append(
-                    nodes.paragraph(text='Possible choices: ' + ', '.join(arg['choices']))
-                )
+                arg_items.append(nodes.paragraph(text=format_choices(arg['choices'])))
             items.append(
                 nodes.option_list_item(
                     '',
@@ -432,9 +434,7 @@ class ArgParseDirective(SphinxDirective):
             elif 'choices' not in opt:
                 opt_items.append(nodes.paragraph(text='Undocumented'))
             if 'choices' in opt:
-                opt_items.append(
-                    nodes.paragraph(text='Possible choices: ' + ', '.join(opt['choices']))
-                )
+                opt_items.append(nodes.paragraph(text=format_choices(opt['choices'])))
             items.append(
                 nodes.option_list_item(
                     '',


### PR DESCRIPTION
We're using an argument with `choices=range(0, 256)`. This leads to a long list of all the options in the generated documentation. This patch reduces code duplication by moving choice formatting to a separate function invoked for action groups, positional arguments, and optional arguments.
The only functional change is that for objects of type `range` with a step of one, formatting is changed from "Possible choices: 0, 1, 2 [...]" to "Value range: 0 to 256"