### PR TITLE
Hide suppressed subcommands

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -222,6 +222,9 @@ def print_subcommands(data, nested_content, markdown_help=False, settings=None):
             else:
                 desc = ['Undocumented']
 
+            if desc[0] == '==SUPPRESS==':
+                continue
+
             # Handle nested content
             subcontent = []
             if child['name'] in definitions:


### PR DESCRIPTION
Suppress subcommands set up with `help=argparse.SUPPRESS` this is already the case for options and defaults.