### PR TITLE
the extension should primarly resolve the srcdir.

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -468,6 +468,10 @@ class ArgParseDirective(SphinxDirective):
         return content
 
     def _open_filename(self):
+        try:
+            return open(os.path.join(self.env.srcdir, self.options['filename']))
+        except OSError:
+            pass
         # try open with given path
         try:
             return open(self.options['filename'])


### PR DESCRIPTION
This is required when building using
`python -m sphinx docs/source docs/build`

from the root of the project.

I would like to refactor this section to use pathlib though.