### PR TITLE
Added default feature to disable ArgumentParser coloring

### DIFF
--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -32,3 +32,11 @@ Linking to action groups
 ------------------------
 
 As of version 0.2.0, action groups (e.g., "Optional arguments", "Required arguments", and subcommands) can be included in tables of contents and external links. The anchor name is the same as the title name (e.g., "Optional arguments"). In cases where titles are duplicated, as is often the case when subcommands are used, ``_repeatX``, where ``X`` is a number, is prepended to duplicate anchor names to ensure that they can all be uniquely linked.
+
+
+Argparse color
+--------------
+
+Since Python 3.14, ``argparse`` uses `colors <https://docs.python.org/3/library/argparse.html#color>`__ in the output by default.
+These ANSI color sequences won't show right at all in the Sphinx output, so this extension will disable colors first in your ``ArgumentParser`` instance before producing the output.
+You can override this default behaviour by passing the ``:color:`` flag to your ``.. argparse`` directive, in this case the color setting of the argument parser is enabled.

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -299,6 +299,7 @@ class ArgParseDirective(SphinxDirective):
         'nodescription': unchanged,
         'markdown': flag,
         'markdownhelp': flag,
+        'color': flag,
     }
 
     def _construct_manpage_specific_structure(self, parser_info):
@@ -538,6 +539,12 @@ class ArgParseDirective(SphinxDirective):
         path = str(self.options['path'])
         if 'prog' in self.options:
             parser.prog = self.options['prog']
+
+        # Argparse in Python 3.14 uses ANSI color codes by default (#72)
+        if hasattr(parser, 'color'):
+            parser.color = 'color' in self.options
+            # Disable colors, unless a flag is present in the user-settings
+
         result = parse_parser(
             parser,
             skip_default_values='nodefault' in self.options,


### PR DESCRIPTION
This changes the `ArgumentParser` options. This seemed easier than [parsing out all ANSI color codes](https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python) instead.

Fixes
- #72

Should first merge:

- [ ] #75 
- [ ] #79 

After #79 we can test coloring in the pipelines.