### PR TITLE
Moved color-disabling into `parse_parser` to fix subparsers

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -540,15 +540,11 @@ class ArgParseDirective(SphinxDirective):
         if 'prog' in self.options:
             parser.prog = self.options['prog']
 
-        # Argparse in Python 3.14 uses ANSI color codes by default (#72)
-        if hasattr(parser, 'color'):
-            parser.color = 'color' in self.options
-            # Disable colors, unless a flag is present in the user-settings
-
         result = parse_parser(
             parser,
             skip_default_values='nodefault' in self.options,
             skip_default_const_values='nodefaultconst' in self.options,
+            color='color' in self.options,
         )
         result = parser_navigate(result, path)
         if 'manpage' in self.options:

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -55,6 +55,18 @@ def _format_usage_without_prefix(parser):
 
 
 def parse_parser(parser, data=None, **kwargs):
+    """Take data from argparse argument parser.
+
+    Keyword arguments:
+        - skip_default_values
+        - skip_default_const_values
+        - color
+    """
+    # Argparse in Python 3.14 uses ANSI color codes by default (#72)
+    if hasattr(parser, 'color'):
+        parser.color = kwargs.get('color', False)
+        # Disable colors, unless a flag is presented through user-settings
+
     if data is None:
         data = {
             'name': '',
@@ -85,6 +97,11 @@ def parse_parser(parser, data=None, **kwargs):
         for name, subaction in action._name_parser_map.items():
             if name in subsection_alias_names:
                 continue
+
+            if hasattr(subaction, 'color'):
+                subaction.color = parser.color
+                # Color is not inherited, must be set again
+
             subalias = subsection_alias[subaction]
             subaction.prog = f'{parser.prog} {name}'
             subdata = {


### PR DESCRIPTION
Also fixes tests. Before, nested `ArgumentParser`s wouldn't have their color setting changed.

Resolves #83 