### PR TITLE
Support `ArgumentParser.fromfile_prefix_chars`

### DIFF
--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -825,7 +825,7 @@ class ArgParseDirective(SphinxDirective):
 
         usage = result['usage']
         if fromfile_prefix:
-            usage += ' [{}file]'.format(fromfile_prefix[0])
+            usage += f' [{fromfile_prefix[0]}file]'
         items.append(nodes.literal_block(text=usage))
 
         if len(fromfile_prefix) > 1:
@@ -833,7 +833,7 @@ class ArgParseDirective(SphinxDirective):
             for i, p in enumerate(fromfile_prefix):
                 if i > 0:
                     children.append(nodes.Text(' or '))
-                children.append(nodes.literal(text='{}file'.format(p)))
+                children.append(nodes.literal(text=f'{p}file'))
             children.append(nodes.Text('.'))
             items.append(nodes.paragraph('', '', *children))
 

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -821,10 +821,21 @@ class ArgParseDirective(SphinxDirective):
         domain = cast('ArgParseDomain', self.env.get_domain(ArgParseDomain.name))
         domain.add_argparse_command(result, node_id, self.index_groups)
 
+        fromfile_prefix = result.get('fromfile_prefix_chars', '')
+
         usage = result['usage']
-        if fromfile_prefix := result.get('fromfile_prefix_chars', ''):
+        if fromfile_prefix:
             usage += ' [{}file]'.format(fromfile_prefix[0])
         items.append(nodes.literal_block(text=usage))
+
+        if len(fromfile_prefix) > 1:
+            children = [nodes.Text('Additional arguments will be read from files passed as ')]
+            for i, p in enumerate(fromfile_prefix):
+                if i > 0:
+                    children.append(nodes.Text(' or '))
+                children.append(nodes.literal(text='{}file'.format(p)))
+            children.append(nodes.Text('.'))
+            items.append(nodes.paragraph('', '', *children))
 
         items.extend(
             self._print_action_groups(

--- a/sphinxarg/ext.py
+++ b/sphinxarg/ext.py
@@ -821,7 +821,11 @@ class ArgParseDirective(SphinxDirective):
         domain = cast('ArgParseDomain', self.env.get_domain(ArgParseDomain.name))
         domain.add_argparse_command(result, node_id, self.index_groups)
 
-        items.append(nodes.literal_block(text=result['usage']))
+        usage = result['usage']
+        if fromfile_prefix := result.get('fromfile_prefix_chars', ''):
+            usage += ' [{}file]'.format(fromfile_prefix[0])
+        items.append(nodes.literal_block(text=usage))
+
         items.extend(
             self._print_action_groups(
                 result,

--- a/sphinxarg/parser.py
+++ b/sphinxarg/parser.py
@@ -76,6 +76,7 @@ def parse_parser(parser, data=None, **kwargs):
         }
     _try_add_parser_attribute(data, parser, 'description')
     _try_add_parser_attribute(data, parser, 'epilog')
+    _try_add_parser_attribute(data, parser, 'fromfile_prefix_chars')
     for action in parser._get_positional_actions():
         if not isinstance(action, _SubParsersAction):
             continue

--- a/test/sample-default-supressed.py
+++ b/test/sample-default-supressed.py
@@ -3,7 +3,8 @@ from argparse import ArgumentParser
 
 def get_parser():
     parser = ArgumentParser(
-        prog='sample-default-suppressed', description='Test suppression of version default',
+        prog='sample-default-suppressed',
+        description='Test suppression of version default',
         fromfile_prefix_chars='=@',
     )
     parser.add_argument(

--- a/test/sample-default-supressed.py
+++ b/test/sample-default-supressed.py
@@ -3,7 +3,8 @@ from argparse import ArgumentParser
 
 def get_parser():
     parser = ArgumentParser(
-        prog='sample-default-suppressed', description='Test suppression of version default'
+        prog='sample-default-suppressed', description='Test suppression of version default',
+        fromfile_prefix_chars='=@',
     )
     parser.add_argument(
         '--version', help='print version number', action='version', version='1.2.3'

--- a/test/sample-directive-special.py
+++ b/test/sample-directive-special.py
@@ -5,6 +5,7 @@ def get_parser():
     parser = argparse.ArgumentParser(
         prog='sample-directive-special',
         description='Support SphinxArgParse HTML testing (with defaults)',
+        fromfile_prefix_chars='@',
     )
 
     parser.add_argument(

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -72,7 +72,10 @@ from test.utils.xpath import check_xpath
                 ('.//h2', 'Named Arguments'),
                 ('.//section/dl/dd/p', 'Default', False),
                 (".//div[@class='highlight']", r'\[=file\]'),
-                ('.//p', 'Additional arguments will be read from files passed as =file or @file.'),
+                (
+                    './/p',
+                    'Additional arguments will be read from files passed as =file or @file.',
+                ),
             ],
         ),
     ],

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -60,6 +60,7 @@ from test.utils.xpath import check_xpath
                 ('.//section/dl/dd/p/code/span', '420'),
                 ('.//section/dl/dd/p/code/span', "'*.rst"),
                 ('.//section/dl/dd/p/code/span', r"\['\*.rst',"),
+                (".//div[@class='highlight']", r'\[@file\]'),
             ],
         ),
         (

--- a/test/test_default_html.py
+++ b/test/test_default_html.py
@@ -61,6 +61,7 @@ from test.utils.xpath import check_xpath
                 ('.//section/dl/dd/p/code/span', "'*.rst"),
                 ('.//section/dl/dd/p/code/span', r"\['\*.rst',"),
                 (".//div[@class='highlight']", r'\[@file\]'),
+                ('.//p', 'Additional arguments will be read from files', False),
             ],
         ),
         (
@@ -70,6 +71,8 @@ from test.utils.xpath import check_xpath
                 ('.//h1', 'Default suppressed'),
                 ('.//h2', 'Named Arguments'),
                 ('.//section/dl/dd/p', 'Default', False),
+                (".//div[@class='highlight']", r'\[=file\]'),
+                ('.//p', 'Additional arguments will be read from files passed as =file or @file.'),
             ],
         ),
     ],

--- a/test/utils/xpath.py
+++ b/test/utils/xpath.py
@@ -1,4 +1,5 @@
 import re
+
 from lxml import etree as lxmletree
 
 

--- a/test/utils/xpath.py
+++ b/test/utils/xpath.py
@@ -1,4 +1,5 @@
 import re
+from lxml import etree as lxmletree
 
 
 def check_xpath(etree, fname, path, check, be_found=True):
@@ -16,12 +17,7 @@ def check_xpath(etree, fname, path, check, be_found=True):
     else:
 
         def get_text(node):
-            if node.text is not None:
-                # the node has only one text
-                return node.text
-            else:
-                # the node has tags and text; gather texts just under the node
-                return ''.join(n.tail or '' for n in node)
+            return lxmletree.tostring(node, encoding='unicode', method='text')
 
         rex = re.compile(check)
         if be_found:


### PR DESCRIPTION
[`ArgumentParser.fromfile_prefix_chars`](https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars) allows specifying a filename to read additional parameters from.  For example, when `fromfile_prefix_chars="@"`, calling `<command> @file.txt` will read `file.txt` for more parameters.

This change adds `[@file]` to the usage line (or whichever character was configured first.)  If there is more than one prefix character configured, there's also a text paragraph added to document all of them.