### PR TITLE
Drop the upper limit for flit_core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >= 3.10, <4"]
+requires = ["flit_core >= 3.10"]
 build-backend = "flit_core.buildapi"
 
 # project metadata


### PR DESCRIPTION
When packaging this project on Arch Linux, the upper-limit on flit_core prevents me from building this package, because we have upgraded flit_core to 4.0.0.